### PR TITLE
correct example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,9 @@ Tablib is an :ref:`MIT Licensed <mit>` format-agnostic tabular dataset library, 
 ::
 
    >>> data = tablib.Dataset(headers=['First Name', 'Last Name', 'Age'])
-   >>> map(data.append, [('Kenneth', 'Reitz', 22), ('Bessie', 'Monke', 21)])
+   >>> for i in [('Kenneth', 'Reitz', 22), ('Bessie', 'Monke', 21)]:
+   ...     data.append(i)
+      
 
    >>> print data.json
    [{"Last Name": "Reitz", "First Name": "Kenneth", "Age": 22}, {"Last Name": "Monke", "First Name": "Bessie", "Age": 21}]


### PR DESCRIPTION
map() is a function in python2, and iterator in python3+;

In any case - map is inefficient compared to either comprehensions (most efficient), or simple loops (close second).
SInce in this case, data.append() returns nothing, use a simple loop.
It is clearer, more efficient, and works with both python2 and python3